### PR TITLE
Corrected spelling error on settings page

### DIFF
--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -10,4 +10,4 @@
     required: true
 }) }}
 
-<p>{{ "Make sure the entered instagram user profil is not private."|t("instagramfeed") }}</p>
+<p>{{ "Make sure the entered instagram user profile is not private."|t("instagramfeed") }}</p>


### PR DESCRIPTION
Profile was missing an 'e' at the end on the settings page.