### PR TITLE
Implement file_get_contents timeout

### DIFF
--- a/src/services/InstagramService.php
+++ b/src/services/InstagramService.php
@@ -63,7 +63,8 @@ class InstagramService extends Component
         $items = [];
 
         $url = sprintf('https://www.instagram.com/%s', $account);
-        $html = @file_get_contents($url);
+        $context = stream_context_create(['http' => ['timeout' => 5000]]);
+        $html = @file_get_contents($url, false, $context);
         if (false === $html) {
             Craft::error('Instagram profile data could not be fetched. Wrong account name or not a public profile.', __METHOD__);
             return [];


### PR DESCRIPTION
I think it makes sense to maintain a reasonably low timeout to avoid the possibility of page hangs in the event that Instagram is offline.

I know a global timeout can be set in the PHP configuration but this should offer a good safety net regardless of configuration. Personally I would use a lower timeout, more like 1 second, but again this offers a good safety net - perhaps in future the timeout could be configurable.